### PR TITLE
remove HITBTC symbols

### DIFF
--- a/crypto/attributes/crypto.json
+++ b/crypto/attributes/crypto.json
@@ -3890,20 +3890,6 @@
       ]
     },
     {
-      "s": "HITBTC:XECBTC",
-      "f": [
-        "eCash",
-        "XEC"
-      ]
-    },
-    {
-      "s": "HITBTC:XECUSD",
-      "f": [
-        "eCash",
-        "XEC"
-      ]
-    },
-    {
       "s": "HUOBI:EKOBTC",
       "f": [
         "EchoLink",
@@ -9984,20 +9970,6 @@
       "f": [
         "ShareToken",
         "SHR"
-      ]
-    },
-    {
-      "s": "HITBTC:SHIBBTC",
-      "f": [
-        "SHIBA INU",
-        "SHIB"
-      ]
-    },
-    {
-      "s": "HITBTC:SHIBUSD",
-      "f": [
-        "SHIBA INU",
-        "SHIB"
       ]
     },
     {


### PR DESCRIPTION
Removed: SHIB, XEC
There are alternatives in COINBASE and BITFINEX.