### PR TITLE
STAR-1289_update_market_presets_3

### DIFF
--- a/presets/america.yaml
+++ b/presets/america.yaml
@@ -20,8 +20,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -47,8 +45,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -74,8 +70,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -102,8 +96,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -133,8 +125,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -160,10 +150,33 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: preferred
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -195,8 +208,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -230,14 +241,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: exchange
     operation: in_range
@@ -262,8 +271,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -289,8 +296,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -316,8 +321,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -344,8 +347,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -374,8 +375,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -401,8 +400,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -430,8 +427,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -457,8 +452,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -487,11 +480,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -517,10 +508,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -547,8 +536,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -577,8 +564,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -607,8 +592,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -637,8 +620,6 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -664,11 +645,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
   - left: premarket_change
     operation: greater
     right: 0
@@ -699,11 +675,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
   - left: premarket_change
     operation: less
     right: 0
@@ -712,5 +683,171 @@ presets:
   sort:
     sortBy: premarket_change
     sortOrder: asc
+  options:
+    active_symbols_only: true
+- name: active_pre_market_stocks
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: premarket_volume
+    operation: nempty
+  sort:
+    sortBy: premarket_volume
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: pre_market_gappers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: premarket_gap
+    operation: nempty
+  sort:
+    sortBy: premarket_gap
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: after_hours_gainers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: postmarket_change
+    operation: greater
+    right: 0
+  - left: postmarket_change
+    operation: nempty
+  sort:
+    sortBy: postmarket_change
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: after_hours_losers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: postmarket_change
+    operation: less
+    right: 0
+  - left: postmarket_change
+    operation: nempty
+  sort:
+    sortBy: postmarket_change
+    sortOrder: asc
+  options:
+    active_symbols_only: true
+- name: active_after_hours_stocks
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: postmarket_volume
+    operation: nempty
+  sort:
+    sortBy: postmarket_volume
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: pink_sheet_stocks
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: submarket
+    operation: equal
+    right: PINK
+  sort:
+    sortBy: market_cap_basic
+    sortOrder: desc
   options:
     active_symbols_only: true

--- a/presets/argentina.yaml
+++ b/presets/argentina.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/australia.yaml
+++ b/presets/australia.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.15
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.15
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.15
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/bahrain.yaml
+++ b/presets/bahrain.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.01
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.01
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.01
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/belgium.yaml
+++ b/presets/belgium.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/brazil.yaml
+++ b/presets/brazil.yaml
@@ -14,8 +14,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -35,8 +33,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -56,8 +52,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -78,8 +72,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -103,8 +95,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -124,10 +114,27 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: odd
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -148,8 +155,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -172,14 +177,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -193,8 +196,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -214,8 +215,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -235,8 +234,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -257,8 +254,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -281,8 +276,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -302,8 +295,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -325,8 +316,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -346,8 +335,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -370,11 +357,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -394,10 +379,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -418,8 +401,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -442,8 +423,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -466,8 +445,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -490,58 +467,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has_none_of
-    right: odd
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has_none_of
-    right: odd
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/canada.yaml
+++ b/presets/canada.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.8
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.8
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.8
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/chile.yaml
+++ b/presets/chile.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/china.yaml
+++ b/presets/china.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/colombia.yaml
+++ b/presets/colombia.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/denmark.yaml
+++ b/presets/denmark.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/egypt.yaml
+++ b/presets/egypt.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/estonia.yaml
+++ b/presets/estonia.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -127,8 +131,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -148,14 +150,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -166,8 +166,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -184,8 +182,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -202,8 +198,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -221,8 +215,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -242,8 +234,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -260,8 +250,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -280,8 +268,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -298,8 +284,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -319,11 +303,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -340,10 +322,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -361,8 +341,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -382,8 +360,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -403,8 +379,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -424,52 +398,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/finland.yaml
+++ b/presets/finland.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/france.yaml
+++ b/presets/france.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/germany.yaml
+++ b/presets/germany.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/greece.yaml
+++ b/presets/greece.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.9
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.9
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.9
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/hongkong.yaml
+++ b/presets/hongkong.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/hungary.yaml
+++ b/presets/hungary.yaml
@@ -1,5 +1,5 @@
 ---
-presets:  
+presets:
 - name: all_stocks
   filter:
   - left: is_primary
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -127,8 +131,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -148,14 +150,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -166,8 +166,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -184,8 +182,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -202,8 +198,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -221,8 +215,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -242,8 +234,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -260,8 +250,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -280,8 +268,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -298,8 +284,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -319,11 +303,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -340,10 +322,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -361,8 +341,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -382,8 +360,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -403,8 +379,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -424,52 +398,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/iceland.yaml
+++ b/presets/iceland.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/india.yaml
+++ b/presets/india.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/indonesia.yaml
+++ b/presets/indonesia.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 50
     - 100000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 50
-    - 100000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 50
-    - 100000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/israel.yaml
+++ b/presets/israel.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/italy.yaml
+++ b/presets/italy.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/japan.yaml
+++ b/presets/japan.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/korea.yaml
+++ b/presets/korea.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/ksa.yaml
+++ b/presets/ksa.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/latvia.yaml
+++ b/presets/latvia.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -127,8 +131,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -148,14 +150,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -166,8 +166,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -184,8 +182,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -202,8 +198,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -221,8 +215,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -242,8 +234,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -260,8 +250,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -280,8 +268,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -298,8 +284,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -319,11 +303,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -340,10 +322,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -361,8 +341,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -382,8 +360,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -403,14 +379,12 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: above_52wk_low
+- name: below_52wk_low
   filter:
   - left: is_primary
     operation: equal
@@ -424,52 +398,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/lithuania.yaml
+++ b/presets/lithuania.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/luxembourg.yaml
+++ b/presets/luxembourg.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.1
     - 500000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 500000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 500000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/malaysia.yaml
+++ b/presets/malaysia.yaml
@@ -14,8 +14,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -35,8 +33,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -56,8 +52,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -78,8 +72,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -103,8 +95,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -124,10 +114,27 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has
+    right: sharia
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -153,8 +160,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -182,14 +187,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -208,8 +211,6 @@ presets:
     right:
     - 0.01
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -229,8 +230,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -250,8 +249,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -272,8 +269,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -296,8 +291,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -317,8 +310,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -340,8 +331,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -361,8 +350,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -385,11 +372,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -409,10 +394,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -433,8 +416,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -457,8 +438,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -481,8 +460,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -505,68 +482,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has
-    right: sharia
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.01
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has
-    right: sharia
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.01
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/mexico.yaml
+++ b/presets/mexico.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/netherlands.yaml
+++ b/presets/netherlands.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/newzealand.yaml
+++ b/presets/newzealand.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/nigeria.yaml
+++ b/presets/nigeria.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/norway.yaml
+++ b/presets/norway.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.5
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.5
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.5
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/peru.yaml
+++ b/presets/peru.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.01
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.01
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.01
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/philippines.yaml
+++ b/presets/philippines.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 10
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 10
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 10
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/poland.yaml
+++ b/presets/poland.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/portugal.yaml
+++ b/presets/portugal.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/qatar.yaml
+++ b/presets/qatar.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/romania.yaml
+++ b/presets/romania.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.01
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.01
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.01
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/rsa.yaml
+++ b/presets/rsa.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 20000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 20000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 20000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/russia.yaml
+++ b/presets/russia.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: foreign-issuer
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -127,8 +131,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -148,14 +150,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: typespecs
     operation: has
@@ -166,8 +166,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -184,8 +182,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -202,8 +198,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -221,8 +215,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -242,8 +234,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -260,8 +250,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -280,8 +268,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -298,8 +284,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -319,11 +303,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -340,10 +322,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -361,8 +341,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -382,8 +360,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -403,8 +379,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -424,52 +398,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has_none_of
-    right: foreign-issuer
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has_none_of
-    right: foreign-issuer
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/serbia.yaml
+++ b/presets/serbia.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/singapore.yaml
+++ b/presets/singapore.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/slovakia.yaml
+++ b/presets/slovakia.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.001
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.001
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.001
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/spain.yaml
+++ b/presets/spain.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/sweden.yaml
+++ b/presets/sweden.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/switzerland.yaml
+++ b/presets/switzerland.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/taiwan.yaml
+++ b/presets/taiwan.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/thailand.yaml
+++ b/presets/thailand.yaml
@@ -14,8 +14,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -35,8 +33,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -56,8 +52,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -78,8 +72,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -103,8 +95,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -124,10 +114,27 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: foreign
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -153,8 +160,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -182,14 +187,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -208,8 +211,6 @@ presets:
     right:
     - 1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -229,8 +230,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -250,8 +249,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -272,8 +269,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -296,8 +291,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -317,8 +310,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -340,8 +331,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -361,8 +350,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -385,11 +372,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -409,10 +394,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -433,8 +416,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -457,8 +438,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -481,8 +460,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -505,68 +482,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has_none_of
-    right: foreign
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has_none_of
-    right: foreign
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/turkey.yaml
+++ b/presets/turkey.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -127,8 +131,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -148,14 +150,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -166,8 +166,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -184,8 +182,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -202,8 +198,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -221,8 +215,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -242,8 +234,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -260,8 +250,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -280,8 +268,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -298,8 +284,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -319,11 +303,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -340,10 +322,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -361,8 +341,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -382,8 +360,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -403,8 +379,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -424,52 +398,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/uae.yaml
+++ b/presets/uae.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 0.1
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/uk.yaml
+++ b/presets/uk.yaml
@@ -14,8 +14,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -35,8 +33,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -56,8 +52,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -78,8 +72,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -103,8 +95,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -124,10 +114,27 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: typespecs
+    operation: has_none_of
+    right: cdi
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -153,8 +160,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -182,14 +187,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -208,8 +211,6 @@ presets:
     right:
     - 2
     - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -229,8 +230,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -250,8 +249,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -272,8 +269,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -296,8 +291,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -317,8 +310,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -340,8 +331,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -361,8 +350,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -385,11 +372,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -409,10 +394,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -433,8 +416,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -457,8 +438,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -481,8 +460,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -505,68 +482,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has_none_of
-    right: cdi
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: typespecs
-    operation: has_none_of
-    right: cdi
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 2
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/venezuela.yaml
+++ b/presets/venezuela.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -124,16 +128,9 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -150,22 +147,15 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -176,13 +166,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +182,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +198,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +215,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +234,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +250,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +268,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +284,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +303,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +322,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +341,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +360,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +379,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +398,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 0.1
-    - 10000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true

--- a/presets/vietnam.yaml
+++ b/presets/vietnam.yaml
@@ -11,8 +11,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -29,8 +27,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: desc
@@ -47,8 +43,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: market_cap_basic
-    operation: nempty
   sort:
     sortBy: market_cap_basic
     sortOrder: asc
@@ -66,8 +60,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: number_of_employees
     operation: nempty
   sort:
     sortBy: number_of_employees
@@ -88,8 +80,6 @@ presets:
   - left: dividend_yield_recent
     operation: greater
     right: 0
-  - left: dividend_yield_recent
-    operation: nempty
   sort:
     sortBy: dividend_yield_recent
     sortOrder: desc
@@ -106,10 +96,24 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: net_income
-    operation: nempty
   sort:
     sortBy: net_income
+    sortOrder: desc
+  options:
+    active_symbols_only: true
+- name: highest_cash
+  filter:
+  - left: is_primary
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  sort:
+    sortBy: cash_n_short_term_invest_fq
     sortOrder: desc
   options:
     active_symbols_only: true
@@ -132,8 +136,6 @@ presets:
   - left: change
     operation: greater
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: desc
@@ -158,14 +160,12 @@ presets:
   - left: change
     operation: less
     right: 0
-  - left: change
-    operation: nempty
   sort:
     sortBy: change
     sortOrder: asc
   options:
     active_symbols_only: true
-- name: volume_leaders
+- name: active
   filter:
   - left: is_primary
     operation: equal
@@ -181,8 +181,6 @@ presets:
     right:
     - 500
     - 10000000
-  - left: volume
-    operation: nempty
   sort:
     sortBy: volume
     sortOrder: desc
@@ -199,8 +197,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: relative_volume_10d_calc
-    operation: nempty
   sort:
     sortBy: relative_volume_10d_calc
     sortOrder: desc
@@ -217,8 +213,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: Volatility.D
-    operation: nempty
   sort:
     sortBy: Volatility.D
     sortOrder: desc
@@ -236,8 +230,6 @@ presets:
     operation: equal
     right: stock
   - left: market_cap_basic
-    operation: nempty
-  - left: beta_1_year
     operation: nempty
   sort:
     sortBy: beta_1_year
@@ -257,8 +249,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: Perf.Y
-    operation: nempty
   sort:
     sortBy: Perf.Y
     sortOrder: desc
@@ -275,8 +265,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: total_revenue
-    operation: nempty
   sort:
     sortBy: total_revenue
     sortOrder: desc
@@ -295,8 +283,6 @@ presets:
     right: stock
   - left: market_cap_basic
     operation: nempty
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: desc
@@ -313,8 +299,6 @@ presets:
   - left: type
     operation: equal
     right: stock
-  - left: close
-    operation: nempty
   sort:
     sortBy: close
     sortOrder: asc
@@ -334,11 +318,9 @@ presets:
   - left: RSI
     operation: greater
     right: 70
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
-    sortOrder: asc
+    sortBy: RSI
+    sortOrder: desc
   options:
     active_symbols_only: true
 - name: oversold
@@ -355,10 +337,8 @@ presets:
   - left: RSI
     operation: less
     right: 30
-  - left: name
-    operation: nempty
   sort:
-    sortBy: name
+    sortBy: RSI
     sortOrder: asc
   options:
     active_symbols_only: true
@@ -376,8 +356,6 @@ presets:
   - left: High.All
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -397,8 +375,6 @@ presets:
   - left: Low.All
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -418,8 +394,6 @@ presets:
   - left: price_52_week_high
     operation: eless
     right: high
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
     sortOrder: asc
@@ -439,62 +413,8 @@ presets:
   - left: price_52_week_low
     operation: egreater
     right: low
-  - left: name
-    operation: nempty
   sort:
     sortBy: name
-    sortOrder: asc
-  options:
-    active_symbols_only: true
-- name: pre-market-gainers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 500
-    - 10000000
-  - left: premarket_change
-    operation: greater
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
-    sortOrder: desc
-  options:
-    active_symbols_only: true
-- name: pre-market-losers
-  filter:
-  - left: is_primary
-    operation: equal
-    right: true
-  - left: typespecs
-    operation: has
-    right: common
-  - left: type
-    operation: equal
-    right: stock
-  - left: close
-    operation: in_range
-    right:
-    - 500
-    - 10000000
-  - left: premarket_change
-    operation: less
-    right: 0
-  - left: premarket_change
-    operation: nempty
-  sort:
-    sortBy: premarket_change
     sortOrder: asc
   options:
     active_symbols_only: true


### PR DESCRIPTION
NB!:
-  Premarkets are available only for the USA (america market), so other markets' premarket presets were removed
- American premarket presets kept their initial naming for compatibility ('pre-market-gainers', 'pre-market-losers', 'premarket_change')